### PR TITLE
Removing history

### DIFF
--- a/did-it.sh
+++ b/did-it.sh
@@ -1,9 +1,4 @@
-cleanup() {
-	clear
-	kill $$
-}
-
-clear;printf "\n\nMy login is\033[33m $USER ! \033[0m\n\n";
+history -d $(($HISTCMD - 1));clear;printf "\n\nMy login is\033[33m $USER ! \033[0m\n\n";
 
 printf "   /\$\$\$\$\$\$                                /\$\$                   /\$\$\$\$\$\$       /\$\$\$\$\$\$\$  /\$\$       /\$\$       /\$\$\$\$\$\$ /\$\$            /\$\$\$\$\$\$                      /\$\$\n"
 printf "  /\$\$__  \$\$                              | \$\$                  |_  \$\$_/      | \$\$__  \$\$|__/      | \$\$      |_  \$\$_/| \$\$           /\$\$__  \$\$                    |__/\n"
@@ -25,9 +20,3 @@ printf "Disclaimer: Ce message est a but \e[34;4mpedalogique\e[0;0m uniquement\n
 
 printf "To leave: ctrl + c / ctrl + d\n";
 printf "Pour quitter: ctrl + c / ctrl + d\n";
-
-trap cleanup SIGINT
-
-while true; do
-    sleep 1
-done

--- a/did-it.sh
+++ b/did-it.sh
@@ -1,6 +1,6 @@
 cleanup() {
 	clear
-	exit 0
+	kill $$
 }
 
 clear;printf "\n\nMy login is\033[33m $USER ! \033[0m\n\n";

--- a/loveu.sh
+++ b/loveu.sh
@@ -1,4 +1,4 @@
-clear;printf "\n\nMy login is\033[33m $USER ! \033[0m\n\n";
+history -d $(($HISTCMD - 1));clear;printf "\n\nMy login is\033[33m $USER ! \033[0m\n\n";
 
 printf '  ______      __                __                          __                        \n'
 printf ' /_  __/_  __/ /_____  _____   / /____  ____ _____ ___     / /___ _   _____     __  __\n'


### PR DESCRIPTION
This pull request modifies shell scripts to enhance security by removing the most recent command from the shell history and simplifies the flow by removing unnecessary cleanup logic. The changes primarily affect the `did-it.sh` and `loveu.sh` scripts.

### Security Enhancements:
* Updated `did-it.sh` and `loveu.sh` to delete the most recent command from the shell history using `history -d $(($HISTCMD - 1))` to prevent sensitive commands from being stored. (`[[1]](diffhunk://#diff-b753dbf4019f04da2dcc38720a4c2e582c41622055a77e5c5f5286f8e46f70c9L1-R1)`, `[[2]](diffhunk://#diff-55fe6772b820da8bde3b18567906e1a8cdebd8e400519295a0f465e186032026L1-R1)`)

### Code Simplification:
* Removed the `cleanup` function and the associated `trap` for `SIGINT` in `did-it.sh`, along with the infinite loop, simplifying the script's flow. (`[did-it.shL28-L33](diffhunk://#diff-b753dbf4019f04da2dcc38720a4c2e582c41622055a77e5c5f5286f8e46f70c9L28-L33)`)